### PR TITLE
Add colgroup to customizations 

### DIFF
--- a/src/Table.elm
+++ b/src/Table.elm
@@ -182,6 +182,7 @@ you have. Stories make it possible to design better!
 type alias Customizations data msg =
   { tableAttrs : List (Attribute msg)
   , caption : Maybe (HtmlDetails msg)
+  , colgroup : Maybe (HtmlDetails msg)
   , thead : List (String, Status, Attribute msg) -> HtmlDetails msg
   , tfoot : Maybe (HtmlDetails msg)
   , tbodyAttrs : List (Attribute msg)
@@ -205,6 +206,7 @@ defaultCustomizations : Customizations data msg
 defaultCustomizations =
   { tableAttrs = []
   , caption = Nothing
+  , colgroup = Nothing
   , thead = simpleThead
   , tfoot = Nothing
   , tbodyAttrs = []
@@ -421,6 +423,22 @@ view (Config { toId, toMsg, columns, customizations }) state data =
     sortedData =
       sort state columns data
 
+    caption =
+      case customizations.caption of
+        Nothing ->
+          identity
+
+        Just { attributes, children } ->
+          (::) <| Html.caption attributes children
+
+    colgroup =
+      case customizations.colgroup of
+        Nothing ->
+          identity
+
+        Just { attributes, children } ->
+          (::) <| Html.colgroup attributes children
+
     theadDetails =
       customizations.thead (List.map (toHeaderInfo state toMsg) columns)
 
@@ -439,13 +457,8 @@ view (Config { toId, toMsg, columns, customizations }) state data =
         Just { attributes, children } ->
           Html.tfoot attributes children :: tbody :: []
   in
-    Html.table customizations.tableAttrs <|
-      case customizations.caption of
-        Nothing ->
-          thead :: withFoot
-
-        Just { attributes, children } ->
-          Html.caption attributes children :: thead :: withFoot
+    Html.table customizations.tableAttrs
+      (caption <| colgroup <| thead :: withFoot)
 
 
 toHeaderInfo : State -> (State -> msg) -> ColumnData data msg -> ( String, Status, Attribute msg )


### PR DESCRIPTION
colgroup is useful for setting properties of whole columns (like width) easily. This would also address #12 (in fact, this is exactly the use case I have). Also, it is also part of HTML so we should include it.