### PR TITLE
<thead> requires only <tr> as children

### DIFF
--- a/src/Table.elm
+++ b/src/Table.elm
@@ -425,7 +425,7 @@ view (Config { toId, toMsg, columns, customizations }) state data =
       customizations.thead (List.map (toHeaderInfo state toMsg) columns)
 
     thead =
-      Html.thead theadDetails.attributes theadDetails.children
+      Html.thead theadDetails.attributes [ Html tr [] theadDetails.children ]
 
     tbody =
       Keyed.node "tbody" customizations.tbodyAttrs <|


### PR DESCRIPTION
According to documents, only `<tr>` is allowed directly under `<thead>`.

https://www.w3.org/TR/html401/struct/tables.html#h-11.2.3
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot