### PR TITLE
Add de/serialization of Table state

### DIFF
--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -4,13 +4,12 @@
     "repository": "https://github.com/user/project.git",
     "license": "BSD3",
     "source-directories": [
-        "."
+        ".", "../src"
     ],
     "exposed-modules": [],
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "evancz/elm-sortable-table": "1.0.1 <= v < 2.0.0"
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,7 +9,27 @@
 </head>
 
 <body>
-	<script type="text/javascript">Elm.Main.fullscreen();</script>
 </body>
+
+<script type="text/javascript">
+    var key = "model";
+    var app = Elm.Main.fullscreen();
+    if (app.ports !== undefined) {
+        if (app.ports.putStorage !== undefined) {
+            app.ports.putStorage.subscribe( function(json) {
+                window.localStorage.setItem(key, JSON.stringify(json))
+            });
+        }
+        if (app.ports.getStorage !== undefined  &&
+            app.ports.fromStorage !== undefined
+           ) {
+               app.ports.getStorage.subscribe( function() {
+                   app.ports.fromStorage.send(
+                       JSON.parse( window.localStorage.getItem(key) )
+                   )
+               });
+        }
+    }
+</script>
 
 </html>

--- a/src/Table.elm
+++ b/src/Table.elm
@@ -7,6 +7,7 @@ module Table exposing
   , increasingOrDecreasingBy, decreasingOrIncreasingBy
   , Config, customConfig
   , Customizations, HtmlDetails, Status(..), defaultCustomizations
+  , encode, decode
   )
 
 {-|
@@ -59,7 +60,7 @@ import Html.Events as E
 import Html.Keyed as Keyed
 import Html.Lazy exposing (lazy2, lazy3)
 import Json.Decode as Json
-
+import Json.Encode as Encode
 
 
 -- STATE
@@ -619,3 +620,20 @@ sort by best time by default, but also see the other order.
 increasingOrDecreasingBy : (data -> comparable) -> Sorter data
 increasingOrDecreasingBy toComparable =
   IncOrDec (List.sortBy toComparable)
+
+
+-- SERIALIZATION
+
+encode : State -> Encode.Value
+encode (State colname isReversed) =
+  Encode.list
+    [ Encode.string colname
+    , Encode.bool isReversed
+    ]
+
+decode : Json.Decoder State
+decode =
+  Json.map2 State
+    (Json.index 0 Json.string)
+    (Json.index 1 Json.bool)
+


### PR DESCRIPTION
This enables the common case where you want to persist table state -- in other
words, to save the last sort order of the table between refreshes.

I changed the 1-presidents example to show how it would be used to save/restore
state to localstorage.