### PR TITLE
Make the table more vimium friendly

### DIFF
--- a/src/Table.elm
+++ b/src/Table.elm
@@ -245,12 +245,12 @@ simpleTheadHelp (name, status, onClick) =
 
 darkGrey : String -> Html msg
 darkGrey symbol =
-  Html.span [ Attr.style [("color", "#555")] ] [ Html.text (" " ++ symbol) ]
+  Html.a [ Attr.style [("color", "#555")] ] [ Html.text (" " ++ symbol) ]
 
 
 lightGrey : String -> Html msg
 lightGrey symbol =
-  Html.span [ Attr.style [("color", "#ccc")] ] [ Html.text (" " ++ symbol) ]
+  Html.a [ Attr.style [("color", "#ccc")] ] [ Html.text (" " ++ symbol) ]
 
 
 simpleRowAttrs : data -> List (Attribute msg)


### PR DESCRIPTION
Currently columns cannot be sorted using vimium (https://chrome.google.com/webstore/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb), because there is no anchor to select.
This trivial change makes the elements that change the sort order selectable with vimium, and possibly other browser extensions.